### PR TITLE
Add License Processing Capability For CycloneDX Generated SBOMs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,5 @@ GitPython~=3.1
 prettytable~=3.8
 packageurl-python>=0.11.1
 license-expression>=30.1
+spdx-license-list>=3.23
 

--- a/tern/formats/cyclonedx/cyclonedx_common.py
+++ b/tern/formats/cyclonedx/cyclonedx_common.py
@@ -10,8 +10,8 @@ Common functions that are useful for CycloneDX document creation
 import datetime
 import uuid
 from tern.utils import general
-import re
-
+import spdx_license_list
+sll = spdx_license_list.LICENSES
 
 ###################
 # General Helpers #
@@ -92,16 +92,7 @@ def get_os_guess(image_obj):
 
 
 def get_license_from_name(name):
-    if name.isupper() is False:
-        name = name.split("-")
-        name = [n.title() if not n.isupper() else n for n in name]
-        name = "-".join(name)
-
-    if "GPLv" in name:
-        name = name.replace("GPLv", "GPL-")
-    
-    if re.search("GPL-[0-9][^\+\.]", name) or re.search("GPL-[0-9]$", name):
-        name2 = re.sub(r"GPL-(\d)",r"GPL-\1.0", name)
-        name = name2
-
-    return {'license': {'id': name}}
+    if sll.get(name) is None:
+        return {'license': {'name': name}}
+    else:
+        return {'license': {'id': name}}

--- a/tern/formats/cyclonedx/cyclonedx_common.py
+++ b/tern/formats/cyclonedx/cyclonedx_common.py
@@ -10,6 +10,7 @@ Common functions that are useful for CycloneDX document creation
 import datetime
 import uuid
 from tern.utils import general
+import re
 
 
 ###################
@@ -91,4 +92,16 @@ def get_os_guess(image_obj):
 
 
 def get_license_from_name(name):
+    if name.isupper() is False:
+        name = name.split("-")
+        name = [n.title() if not n.isupper() else n for n in name]
+        name = "-".join(name)
+
+    if "GPLv" in name:
+        name = name.replace("GPLv", "GPL-")
+    
+    if re.search("GPL-[0-9][^\+\.]", name) or re.search("GPL-[0-9]$", name):
+        name2 = re.sub(r"GPL-(\d)",r"GPL-\1.0", name)
+        name = name2
+
     return {'license': {'id': name}}


### PR DESCRIPTION
When generating CycloneDX (JSON) SBOMs, license information is added in the form of a License ID, as following:

```python
def get_license_from_name(name):
    return {'license': {'id': name}}
```
in file ```tern/tern/formats/cyclonedx/cyclonedx_common.py```.

When this license information is not a valid SPDX license ID, as defined in the [CycloneDX JSON Schema](https://cyclonedx.org/docs/1.3/json/#components_items_licenses_items_license_id), it results in an invalid SBOM.

E.g. GPLv2+ (incorrect) as opposed to GPL-2.0+ (correct).

This proposed fix alters the  ```get_license_from_name``` function to validate the name input as a valid SPDX license ID, utilising the [spdx-license-list](https://github.com/JJMC89/spdx-license-list) python module. 

If this validation fails, the ```get_license_from_name``` function returns the license as a CycloneDX [License Name](https://cyclonedx.org/docs/1.3/json/#components_items_licenses_items_license_name), which can be any string. 


